### PR TITLE
Handle reload redirect and pass real moon phase

### DIFF
--- a/js/fate.js
+++ b/js/fate.js
@@ -6,6 +6,12 @@ function shuffleArray(array) {
 }
 
 window.addEventListener("DOMContentLoaded", async () => {
+  const realPhase = sessionStorage.getItem("realPhase");
+  if (!realPhase) {
+    window.location.href = "index.html";
+    return;
+  }
+  sessionStorage.removeItem("realPhase");
   const img = document.getElementById("result-image");
   const attr = document.getElementById("result-attributes");
   const desc = document.getElementById("result-description");
@@ -52,6 +58,7 @@ window.addEventListener("DOMContentLoaded", async () => {
     <p>卡牌面向：${direction}</p>
     <p>所屬分組：${rune.所屬分組}</p>
     <p>月相：${rune.月相}</p>
+    <p>真實月相：${realPhase}</p>
   `;
 
   // 顯示解釋

--- a/js/result.js
+++ b/js/result.js
@@ -11,6 +11,7 @@ window.addEventListener("load", async () => {
   const lunarDay = today.getDate(); // 取農曆日
   const realPhase = getLunarPhase(lunarDay); // 獲取月相
   moonText.textContent = "月相：無 / 真實月相：" + realPhase;
+  sessionStorage.setItem("realPhase", realPhase);
 
   const messages = [
 	"占卜中，請稍等................",


### PR DESCRIPTION
## Summary
- store the calculated real moon phase in `sessionStorage` on **result.html**
- on **fate.html** read the stored phase, redirect if absent, remove it afterwards
- display the real moon phase under the regular moon phase in the result

## Testing
- `npm test` *(fails: could not find `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_68409b0c2580832d99c200c499720db3