### PR TITLE
Update backgrounds and fate color logic

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1,7 +1,7 @@
 body {
   margin: 0;
   font-family: "Noto Sans TC", sans-serif;
-  background-color: #fdfdfd;
+  background-color: #ffffff;
   color: #222;
 }
 .container {

--- a/js/fate.js
+++ b/js/fate.js
@@ -32,6 +32,17 @@ window.addEventListener("DOMContentLoaded", async () => {
 
   const rune = Object.values(runes).find(r => r.編號 === selectedIndex);
   const dirInfo = dirData.find(d => d.編號 === selectedIndex);
+
+  // 根據所屬分組設定背景顏色
+  const groupColorMap = {
+    "靈魂連結": "#00008B",
+    "自然生命": "#006400",
+    "元素力量": "#8B7500",
+    "時空循環": "#8B0000",
+    "宇宙無常": "#2F2F2F",
+  };
+  const bgColor = groupColorMap[rune.所屬分組] || "#ffffff";
+  document.body.style.backgroundColor = bgColor;
   const directionIndex = Math.floor(Math.random() * 4);
   const directions = ["正位", "半正位", "半逆位", "逆位"];
   const directionMeanings = {


### PR DESCRIPTION
## Summary
- make global background pure white
- change fate page background color by rune group

## Testing
- `npm --version`

------
https://chatgpt.com/codex/tasks/task_e_68409df08278832d8e54211db2489c38