### PR TITLE
Add LLM suggestions

### DIFF
--- a/js/fate.js
+++ b/js/fate.js
@@ -62,6 +62,9 @@ window.addEventListener("DOMContentLoaded", async () => {
   };
   const directionResult = dirInfo ? dirInfo[orientationFieldMap[direction]] : "";
 
+  // 產生建議文字的佔位
+  let llmSuggestion = "建議生成中...";
+
   // 顯示符文圖片與屬性
   img.src = "images/" + rune.圖檔名稱;
   attr.innerHTML = `
@@ -82,9 +85,26 @@ window.addEventListener("DOMContentLoaded", async () => {
     <p><strong>實踐挑戰：</strong>${rune.實踐挑戰}</p>
     <p><strong>配套儀式：</strong>${rune.配套儀式建議}</p>
     <p><strong>能量調和：</strong>${rune.能量調和建議}</p>
-        <HR><p>占卜結論： ${rune.符文名稱} ，${direction} 表示，${directionResult}</p><HR>
-	
+        <HR><p>占卜結論： ${rune.符文名稱} ，${direction} 表示，${directionResult}</p>
+        <p id="llm-suggestion">${llmSuggestion}</p><HR>
+
   `;
+
+  // 透過 Transformers.js 取得建議文字
+  try {
+    if (!window.transformers) {
+      await import('https://cdn.jsdelivr.net/npm/@xenova/transformers@2.10.0/dist/transformers.min.js');
+    }
+    const { pipeline } = window.transformers;
+    const generator = await pipeline('text-generation', 'Xenova/distilgpt2');
+    const prompt = `${directionResult}，請針對這個狀況提出30字的生活建議、30字的情緒建議跟30字的健康建議`;
+    const output = await generator(prompt, { max_new_tokens: 120 });
+    const resultText = output[0]?.generated_text ?? '';
+    llmSuggestion = resultText.replace(prompt, '').trim();
+  } catch (e) {
+    llmSuggestion = '建議產生失敗，請稍後再試。';
+  }
+  document.getElementById('llm-suggestion').textContent = llmSuggestion;
 
   // 重新占卜
   retry.addEventListener("click", () => {


### PR DESCRIPTION
## Summary
- add placeholder and generator for LLM guidance
- fetch Transformers.js and generate suggestions after fortune telling text

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6840a980eaf4832da43da16ac2c16e68