### PR TITLE
Upgrade to 64 rune images

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@ moon-runes-pwa/
 │   ├── main.js         # 首頁邏輯（啟動占卜）
 │   └── result.js       # 占卜結果處理邏輯
 ├── data/
-│   └── runes.json      # 符文資料總表（由 Excel 匯出）
-├── images/
-│   └── 01_靈.png ～ 42_憶.png
+│   └── runes64.json    # 符文資料總表（由 Excel 匯出）
+├── 64images/
+│   └── 01_靈.png ～ 66_命.png
 └── README.md           # 本說明文件
 ```
 
@@ -30,8 +30,8 @@ moon-runes-pwa/
 ## 🚀 功能說明
 
 ### 1️⃣ 首頁 index.html
-- 顯示語之符文（語.png）
-- 點擊圖卡進入占卜流程（切換為憶.png）
+- 顯示玄之符文（玄.png）
+- 點擊圖卡進入占卜流程（切換為命.png）
 - 顯示洗牌動畫與說明文字
 - 根據農曆日自動推算月相
 - 模擬洗牌 → 抽出一張符文編號與方向 → 導向 result.html
@@ -57,7 +57,7 @@ moon-runes-pwa/
 
 ## 📦 資料來源
 
-`data/runes.json` 是由 `LunaRune40.xlsx` 匯出整合而成，整合以下欄位：
+`data/runes64.json` 是由 `LunaRune64.xlsx` 匯出整合而成，整合以下欄位：
 - 編號、名稱、圖騰、顯化形式、分組、月相、靈魂咒語
 - 靈魂課題、實踐挑戰、分組說明、符文變化歷史、圖片檔案名
 

--- a/index.html
+++ b/index.html
@@ -13,11 +13,11 @@
     <div class="main-layout">
       <div class="left-panel">
         <div class="card-display" id="rune-card">
-          <img src="images/41_語.png" alt="語之符文" id="rune-image" />
+          <img src="64images/65_玄.png" alt="玄之符文" id="rune-image" />
         </div>
         <div class="card-attributes" id="attributes">
           <p>卡牌面向：正位</p>
-          <p>介紹：「語」，月之符文所述說</p>
+          <p>介紹：「玄」，月之符文所揭示</p>
           <p>所屬分組：它就是全部</p>
           <p>月相：無 / 真實月相：探測中</p>
         </div>
@@ -26,7 +26,7 @@
         <div class="description" id="description">
           <p>歡迎使用月之符文占卜系統！</p>
           <p>若要問事，請先將所問之事，默念三次，</p>
-          <p>再按下左方「語之符文」牌，開始占卜。</p>
+          <p>再按下左方「玄之符文」牌，開始占卜。</p>
           <p>等待片刻，命運軌跡之照將會呈現眼前。</p>
           <p>熱心提醒，短時間再問同樣或類似的問題，只會得到一團混亂的命運軌跡。</p>
           <p>你的意志，會為你指引方向。</p>

--- a/js/fate-org.js
+++ b/js/fate-org.js
@@ -12,16 +12,16 @@ window.addEventListener("DOMContentLoaded", async () => {
   const retry = document.getElementById("retry-button");
 
   // 隨機抽取符文
-  let fateArray = Array.from({ length: 40 }, (_, i) => i + 1);
+  let fateArray = Array.from({ length: 64 }, (_, i) => i + 1);
   shuffleArray(fateArray);
   shuffleArray(fateArray);
   shuffleArray(fateArray);
   const selectedIndex = fateArray[Math.floor(Math.random() * fateArray.length)];
 
   // 從 JSON 獲取符文資料
-  const response = await fetch("data/runes.json");
+  const response = await fetch("data/runes64.json");
   const runes = await response.json();
-  const dirResponse = await fetch("data/direction.json");
+  const dirResponse = await fetch("data/direction64.json");
   const dirData = await dirResponse.json();
 
   const rune = Object.values(runes).find(r => r.編號 === selectedIndex);
@@ -46,7 +46,7 @@ window.addEventListener("DOMContentLoaded", async () => {
   const directionResult = dirInfo ? dirInfo[orientationFieldMap[direction]] : "";
 
   // 顯示符文圖片與屬性
-  img.src = "images/" + rune.圖檔名稱;
+  img.src = "64images/" + rune.圖檔名稱;
   attr.innerHTML = `
     <p>介紹：${rune.符文名稱}</p>
     <p>卡牌面向：${direction}</p>

--- a/js/fate.js
+++ b/js/fate.js
@@ -18,16 +18,16 @@ window.addEventListener("DOMContentLoaded", async () => {
   const retry = document.getElementById("retry-button");
 
   // 隨機抽取符文
-  let fateArray = Array.from({ length: 40 }, (_, i) => i + 1);
+  let fateArray = Array.from({ length: 64 }, (_, i) => i + 1);
   shuffleArray(fateArray);
   shuffleArray(fateArray);
   shuffleArray(fateArray);
   const selectedIndex = fateArray[Math.floor(Math.random() * fateArray.length)];
 
   // 從 JSON 獲取符文資料
-  const response = await fetch("data/runes.json");
+  const response = await fetch("data/runes64.json");
   const runes = await response.json();
-  const dirResponse = await fetch("data/direction.json");
+  const dirResponse = await fetch("data/direction64.json");
   const dirData = await dirResponse.json();
 
   const rune = Object.values(runes).find(r => r.編號 === selectedIndex);
@@ -66,7 +66,7 @@ window.addEventListener("DOMContentLoaded", async () => {
   let llmSuggestion = "建議生成中...";
 
   // 顯示符文圖片與屬性
-  img.src = "images/" + rune.圖檔名稱;
+  img.src = "64images/" + rune.圖檔名稱;
   attr.innerHTML = `
     <p>介紹：${rune.符文名稱}</p>
     <p>卡牌面向：${direction}</p>

--- a/js/result.js
+++ b/js/result.js
@@ -3,8 +3,8 @@ window.addEventListener("load", async () => {
   const description = document.getElementById("description");
   const moonText = document.getElementById("moon-phase");
 
-  // 假設選擇的符文是 "憶"
-  img.src = "images/42_憶.png"; // 設置圖片為憶符文
+  // 假設選擇的符文是 "命"
+  img.src = "64images/66_命.png"; // 設置圖片為命符文
 
   // 假設月相計算（簡化為根據當前日期）
   const today = new Date();

--- a/result.html
+++ b/result.html
@@ -12,11 +12,11 @@
     <div class="main-layout">
       <div class="left-panel">
         <div class="card-display">
-          <img src="images/42_憶.png" alt="憶之符文" id="result-image" />
+          <img src="64images/66_命.png" alt="命之符文" id="result-image" />
         </div>
         <div class="card-attributes">
           <p>卡牌面向：正位</p>
-          <p>介紹：「憶」，所有人的回憶</p>
+          <p>介紹：「命」，所有人的軌跡</p>
           <p>所屬分組：它不屬於全部</p>
           <p id="moon-phase">月相：無 / 真實月相：計算中...</p>
         </div>

--- a/service-worker.js
+++ b/service-worker.js
@@ -6,7 +6,7 @@ self.addEventListener('install', (event) => {
         '/index.html',
         '/style.css',
         '/js/main.js',
-        '/images/41_語.png',
+        '/64images/65_玄.png',
         // 更多需要快取的檔案
       ]);
     })


### PR DESCRIPTION
## Summary
- switch placeholder cards to new 65/66 images
- update rune data paths to `runes64.json` and `direction64.json`
- draw 64 runes instead of 40 in `fate.js`
- update text and doc references for new assets

## Testing
- `node -v`


------
https://chatgpt.com/codex/tasks/task_e_685cfea2c888832d953c5ac0c54300fd