### PR TITLE
Add shared moon phase calculation

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,7 +19,7 @@
           <p>卡牌面向：正位</p>
           <p>介紹：「玄」，月之符文所揭示</p>
           <p>所屬分組：它就是全部</p>
-          <p>月相：無 / 真實月相：探測中</p>
+          <p id="moon-phase-index">月相：無 / 真實月相：探測中</p>
         </div>
       </div>
       <div class="right-panel">
@@ -37,6 +37,7 @@
       <p><strong>By</strong> 月語之境工作室 ｜ <a href="mailto:esotericverse.xy@gmail.com">聯絡我們</a></p>
     </footer>
   </div>
+  <script src="https://cdn.jsdelivr.net/npm/solarlunar@2.0.7/lib/solarlunar.min.js"></script>
   <script src="js/main.js"></script>
 </body>
 </html>

--- a/js/main.js
+++ b/js/main.js
@@ -1,6 +1,31 @@
+function getLunarPhase(day) {
+  if (day >= 1 && day <= 7) return "新月";
+  if (day >= 8 && day <= 14) return "上弦";
+  if (day >= 15 && day <= 21) return "滿月";
+  if (day >= 22 && day <= 30) return "下弦";
+  return "未知";
+}
+
 window.addEventListener("DOMContentLoaded", () => {
   const image = document.getElementById("rune-image");
   const card = document.getElementById("rune-card");
+  const moonText = document.getElementById("moon-phase-index");
+
+  let realPhase = sessionStorage.getItem("realPhase");
+  if (!realPhase) {
+    const today = new Date();
+    const solarYear = today.getFullYear();
+    const solarMonth = today.getMonth() + 1;
+    const solarDay = today.getDate();
+    const lunarInfo = solarlunar.solar2lunar(solarYear, solarMonth, solarDay);
+    const lunarDay = lunarInfo.lDay;
+    realPhase = getLunarPhase(lunarDay);
+    sessionStorage.setItem("realPhase", realPhase);
+  }
+
+  if (moonText) {
+    moonText.textContent = `月相：無 / 真實月相：${realPhase}`;
+  }
 
   // 點擊事件：跳轉到占卜結果頁面
   card.addEventListener("click", () => {

--- a/js/result.js
+++ b/js/result.js
@@ -6,23 +6,19 @@ window.addEventListener("load", async () => {
   // 設置圖片為命符文
   img.src = "64images/66_命.png";
 
-  // 西曆日期
-  const today = new Date();
-  const solarYear = today.getFullYear();
-  const solarMonth = today.getMonth() + 1;
-  const solarDay = today.getDate();
-
-  // 使用 solarlunar 轉換為農曆資訊
-  const lunarInfo = solarlunar.solar2lunar(solarYear, solarMonth, solarDay);
-  const lunarDay = lunarInfo.lDay; // 農曆數字日期（1～30）
-
-  // 除錯資訊
-  console.log(`今日西曆：${solarYear}/${solarMonth}/${solarDay}`);
-  console.log("農曆轉換資訊：", lunarInfo);
-  console.log("農曆日數：", lunarDay);
-
-  const realPhase = getLunarPhase(lunarDay);
-  console.log("判定月相為：", realPhase);
+  let realPhase = sessionStorage.getItem("realPhase");
+  if (!realPhase) {
+    const today = new Date();
+    const solarYear = today.getFullYear();
+    const solarMonth = today.getMonth() + 1;
+    const solarDay = today.getDate();
+    const lunarInfo = solarlunar.solar2lunar(solarYear, solarMonth, solarDay);
+    const lunarDay = lunarInfo.lDay;
+    console.log(`今日西曆：${solarYear}/${solarMonth}/${solarDay}`);
+    console.log("農曆轉換資訊：", lunarInfo);
+    console.log("農曆日數：", lunarDay);
+    realPhase = getLunarPhase(lunarDay);
+  }
 
   moonText.textContent = "月相：無 / 真實月相：" + realPhase;
   sessionStorage.setItem("realPhase", realPhase);


### PR DESCRIPTION
## Summary
- determine lunar phase when entering `index.html`
- share the phase via `sessionStorage`
- show lunar phase on index and result pages using the stored value

## Testing
- `npm test` *(fails: no package.json / network)*

------
https://chatgpt.com/codex/tasks/task_e_685f69d71d80832daade23f254dae527