### PR TITLE
Compare moon phases in fate output

### DIFF
--- a/js/fate.js
+++ b/js/fate.js
@@ -31,6 +31,8 @@ window.addEventListener("DOMContentLoaded", async () => {
   const runes = await runeResponse.json();
   const dirResponse = await fetch("data/direction64.json");
   const dirData = await dirResponse.json();
+  const moonResponse = await fetch("data/moon.json");
+  const moonData = await moonResponse.json();
 
   const rune = runes[runeKey];
 
@@ -62,6 +64,8 @@ window.addEventListener("DOMContentLoaded", async () => {
   // 取得對應方向描述
   const dirInfo = dirData.find(d => d.編號 === rune.編號);
   const directionResult = dirInfo ? dirInfo[orientationFieldMap[direction]] : "無對應解釋";
+  const moonComparison =
+    (moonData[realPhase] && moonData[realPhase][rune.月相]) || "無比對結果";
 
   // 顯示圖片
   img.src = "64images/" + rune.圖檔名稱;
@@ -86,6 +90,7 @@ window.addEventListener("DOMContentLoaded", async () => {
     <p><strong>配套儀式：</strong>${rune.配套儀式建議}</p>
     <p><strong>能量調和：</strong>${rune.能量調和建議}</p>
     <hr>
+    <p>月相比對趨勢：${moonComparison}</p>
     <p>占卜結論：${rune.符文名稱}，${direction} 表示，${directionResult}</p>
     <hr>
   `;


### PR DESCRIPTION
## Summary
- load `data/moon.json` in `fate.js`
- show moon phase comparison result between HR and fortune result

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685fac1a67d4832db816154ddf3e866d