### PR TITLE
Fix orientation for half-facing runes

### DIFF
--- a/js/fate.js
+++ b/js/fate.js
@@ -74,10 +74,10 @@ window.addEventListener("DOMContentLoaded", async () => {
   // 根據方向旋轉圖片
   switch (orientationNumber) {
     case 2:
-      img.style.transform = "rotate(-90deg)"; // 半正位：向左轉 90 度
+      img.style.transform = "rotate(90deg)"; // 半正位：向右轉 90 度
       break;
     case 3:
-      img.style.transform = "rotate(90deg)"; // 半逆位：向右轉 90 度
+      img.style.transform = "rotate(-90deg)"; // 半逆位：向左轉 90 度
       break;
     case 4:
       img.style.transform = "rotate(180deg)"; // 逆位：轉 180 度


### PR DESCRIPTION
## Summary
- correct the rotation angles for 半正位 and 半逆位 images so the directions are not mirrored

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685fe920a50c832daedb20a7c8c890e7