### PR TITLE
Add daily fortune page

### DIFF
--- a/daily.html
+++ b/daily.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="zh-Hant">
+<head>
+  <meta charset="UTF-8" />
+  <base href="/moon-runes-pwa/" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>每日占卜</title>
+  <link rel="stylesheet" href="css/style.css" />
+</head>
+<body>
+  <div class="container">
+    <div class="main-layout">
+      <div class="left-panel">
+        <div class="card-display">
+          <img id="daily-image" src="" alt="占卜符文圖像" />
+        </div>
+        <div class="card-attributes" id="daily-attributes"></div>
+      </div>
+      <div class="right-panel">
+        <div class="description" id="daily-description"></div>
+        <div style="text-align: center; margin-top: 2rem;">
+          <button id="retry-button">重新占卜</button>
+        </div>
+      </div>
+    </div>
+    <footer>
+      <p><strong>By</strong> 月語之境工作室 ｜ <a href="mailto:esotericverse.xy@gmail.com">聯絡我們</a></p>
+    </footer>
+  </div>
+  <script src="js/daily.js"></script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -32,7 +32,7 @@
 		  <p>只會得到一團混亂的命運軌跡。</p>
           <p>你的意志，會為你指引方向。</p>
 		  <P></P><P></P><P></P><HR>
-		  <P>月之符文每日占卜區(占卜提醒、占卜引導、占卜祝福）</P>
+                  <P><a href="result.html?mode=daily">月之符文每日占卜區(占卜提醒、占卜引導、占卜祝福）</a></P>
 		  <P>月之符文牌組抽牌區<select id="MoreCards" name="MoreCards">
   <option value="2card">雙牌</option>
   <option value="3card">三牌</option>

--- a/js/daily.js
+++ b/js/daily.js
@@ -1,0 +1,102 @@
+function shuffleArray(array) {
+  for (let i = array.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [array[i], array[j]] = [array[j], array[i]];
+  }
+}
+
+window.addEventListener("DOMContentLoaded", async () => {
+  const realPhase = sessionStorage.getItem("realPhase");
+  if (!realPhase) {
+    window.location.href = "index.html";
+    return;
+  }
+  sessionStorage.removeItem("realPhase");
+
+  const img = document.getElementById("daily-image");
+  const attr = document.getElementById("daily-attributes");
+  const desc = document.getElementById("daily-description");
+  const retry = document.getElementById("retry-button");
+
+  let fateArray = Array.from({ length: 64 }, (_, i) => i + 1);
+  shuffleArray(fateArray);
+  shuffleArray(fateArray);
+  shuffleArray(fateArray);
+  const selectedIndex = fateArray[Math.floor(Math.random() * fateArray.length)];
+  const runeKey = selectedIndex.toString().padStart(2, "0");
+
+  const runeResponse = await fetch("data/runes64.json");
+  const runes = await runeResponse.json();
+  const rune = runes[runeKey];
+
+  if (!rune) {
+    attr.innerHTML = "<p>⚠️ 無法載入符文資料</p>";
+    return;
+  }
+
+  const directions = ["正位", "半正位", "半逆位", "逆位"];
+  const directionIndex = Math.floor(Math.random() * 4);
+  const orientationNumber = directionIndex + 1;
+  const direction = directions[directionIndex];
+
+  img.src = "64images/" + rune.圖檔名稱;
+  switch (orientationNumber) {
+    case 2:
+      img.style.transform = "rotate(90deg)";
+      break;
+    case 3:
+      img.style.transform = "rotate(-90deg)";
+      break;
+    case 4:
+      img.style.transform = "rotate(180deg)";
+      break;
+    default:
+      img.style.transform = "rotate(0deg)";
+  }
+
+  attr.innerHTML = `
+    <p>介紹：${rune.符文名稱}</p>
+    <p>卡牌面向：${direction}</p>
+    <p>所屬分組：${rune.所屬分組}</p>
+    <p>符文月相：${rune.月相}</p>
+    <p>真實月相：${realPhase}</p>
+  `;
+
+  const groupMap = {
+    "靈魂": "01",
+    "連結": "02",
+    "生命": "03",
+    "自然": "04",
+    "礦物": "05",
+    "元素": "06",
+    "秩序": "07",
+    "無序": "08",
+  };
+
+  const fileId = groupMap[rune.所屬分組];
+  let info;
+  if (fileId) {
+    const groupData = await fetch(`data/group/${fileId}.json`).then(r => r.json());
+    info = groupData.find(
+      d => d.符文名稱 === rune.符文名稱 && d.卡牌方向 === direction && d.現在月相 === realPhase
+    );
+  }
+
+  if (info) {
+    desc.innerHTML = `
+      <p><strong>狀況形容：</strong>${info.狀況形容}</p>
+      <p><strong>狀況表達：</strong>${info.狀況表達}</p>
+      <p><strong>每日占卜提醒：</strong>${info.每日占卜提醒}</p>
+      <p><strong>每日占卜引導：</strong>${info.每日占卜引導}</p>
+      <p><strong>每日占卜祝福：</strong>${info.每日占卜祝福}</p>
+    `;
+  } else {
+    desc.innerHTML = "<p>⚠️ 無法載入每日占卜資料</p>";
+  }
+
+  retry.addEventListener("click", () => {
+    setTimeout(() => {
+      window.location.href = "index.html";
+    }, 1000);
+  });
+});

--- a/js/result.js
+++ b/js/result.js
@@ -1,4 +1,7 @@
 window.addEventListener("load", async () => {
+  const params = new URLSearchParams(window.location.search);
+  const mode = params.get("mode");
+
   const img = document.getElementById("result-image");
   const description = document.getElementById("description");
   const moonText = document.getElementById("moon-phase");
@@ -39,8 +42,9 @@ window.addEventListener("load", async () => {
       index++;
       setTimeout(showNext, 2000);
     } else {
+      const target = mode === "daily" ? "daily.html" : "fate.html";
       setTimeout(() => {
-        window.location.href = "fate.html";
+        window.location.href = target;
       }, 1000);
     }
   }


### PR DESCRIPTION
## Summary
- link index page to a new daily fortune flow
- allow result page to redirect to daily.html using `mode` query parameter
- implement `daily.html` page layout
- implement `js/daily.js` to load group-based daily guidance

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68781e123fa0832db7d2b9737127728f