### PR TITLE
Implement basic daily rune page

### DIFF
--- a/daily.html
+++ b/daily.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="zh-Hant">
+<head>
+  <base href="/moon-runes-pwa/" />
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>每日符文</title>
+  <link rel="stylesheet" href="css/style.css" />
+</head>
+<body>
+  <div class="container">
+    <div class="main-layout">
+      <div class="left-panel">
+        <div class="card-display" id="daily-image"></div>
+      </div>
+      <div class="right-panel">
+        <div class="description" id="daily-info"></div>
+      </div>
+    </div>
+    <footer>
+      <p><strong>By</strong> 月語之境工作室 ｜ <a href="mailto:esotericverse.xy@gmail.com">聯絡我們</a></p>
+    </footer>
+  </div>
+  <script src="js/daily.js"></script>
+</body>
+</html>

--- a/js/daily.js
+++ b/js/daily.js
@@ -1,0 +1,27 @@
+window.addEventListener('load', async () => {
+  try {
+    const res = await fetch('data/runes64.json');
+    const runes = await res.json();
+    const now = new Date();
+    const start = new Date(now.getFullYear(), 0, 0);
+    const dayOfYear = Math.floor((now - start) / 86400000);
+    const index = dayOfYear % runes.length;
+    const rune = runes[index];
+
+    const img = document.createElement('img');
+    img.src = '64images/' + rune['圖檔名稱'];
+    img.alt = rune['符文名稱'];
+    document.getElementById('daily-image').appendChild(img);
+
+    const info = `
+      <p>今日符文：${rune['符文名稱']}</p>
+      <p>所屬分組：${rune['所屬分組']}</p>
+      <p>靈魂課題：${rune['靈魂課題']}</p>
+      <p>實踐挑戰：${rune['實踐挑戰']}</p>
+    `;
+    document.getElementById('daily-info').innerHTML = info;
+  } catch (err) {
+    console.error(err);
+    document.getElementById('daily-info').textContent = '⚠️ 無法載入每日符文';
+  }
+});


### PR DESCRIPTION
## Summary
- add simple daily rune page
- load random daily rune info from existing runes64.json

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68782221a9ac832db99d5993e4fe974f